### PR TITLE
Fix: Correct typo in viewState variable name

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,13 +16,13 @@ const INITIAL_VIEW_STATE = {
 };
 
 function App() {
-  const [viwState, setViewState] = useState(INITIAL_VIEW_STATE)
+  const [viewState, setViewState] = useState(INITIAL_VIEW_STATE)
 
 
   return (
     <div>
       <DeckGL
-        initialViewState={viwState}
+        initialViewState={viewState}
         controller={true}
         layers={renderLayers({})}
       >


### PR DESCRIPTION
The variable `viwState` in `src/App.jsx` has been renamed to `viewState` to correct a typographical error. This affects its declaration using `useState` and its usage in the `DeckGL` component's `initialViewState` prop.